### PR TITLE
added basic mouse controls: rclick zoom, lclick rotate, mclick pan

### DIFF
--- a/scenes/cornell.txt
+++ b/scenes/cornell.txt
@@ -56,7 +56,7 @@ ITERATIONS  5000
 DEPTH       8
 FILE        cornell
 EYE         0.0 5 10.5
-VIEW        0 0 -1
+LOOKAT      0 5 0
 UP          0 1 0
 
 

--- a/scenes/sphere.txt
+++ b/scenes/sphere.txt
@@ -16,7 +16,7 @@ ITERATIONS  5000
 DEPTH       8
 FILE        sphere
 EYE         0.0 5 10.5
-VIEW        0 0 -1
+LOOKAT      0 5 0
 UP          0 1 0
 
 // Sphere

--- a/src/main.h
+++ b/src/main.h
@@ -34,3 +34,5 @@ extern int height;
 
 void runCuda();
 void keyCallback(GLFWwindow *window, int key, int scancode, int action, int mods);
+void mousePositionCallback(GLFWwindow* window, double xpos, double ypos);
+void mouseButtonCallback(GLFWwindow* window, int button, int action, int mods);

--- a/src/preview.cpp
+++ b/src/preview.cpp
@@ -146,6 +146,8 @@ bool init() {
     }
     glfwMakeContextCurrent(window);
     glfwSetKeyCallback(window, keyCallback);
+    glfwSetCursorPosCallback(window, mousePositionCallback);
+    glfwSetMouseButtonCallback(window, mouseButtonCallback);
 
     // Set up GL context
     glewExperimental = GL_TRUE;

--- a/src/scene.cpp
+++ b/src/scene.cpp
@@ -120,8 +120,8 @@ int Scene::loadCamera() {
         vector<string> tokens = utilityCore::tokenizeString(line);
         if (strcmp(tokens[0].c_str(), "EYE") == 0) {
             camera.position = glm::vec3(atof(tokens[1].c_str()), atof(tokens[2].c_str()), atof(tokens[3].c_str()));
-        } else if (strcmp(tokens[0].c_str(), "VIEW") == 0) {
-            camera.view = glm::vec3(atof(tokens[1].c_str()), atof(tokens[2].c_str()), atof(tokens[3].c_str()));
+        } else if (strcmp(tokens[0].c_str(), "LOOKAT") == 0) {
+            camera.lookAt = glm::vec3(atof(tokens[1].c_str()), atof(tokens[2].c_str()), atof(tokens[3].c_str()));
         } else if (strcmp(tokens[0].c_str(), "UP") == 0) {
             camera.up = glm::vec3(atof(tokens[1].c_str()), atof(tokens[2].c_str()), atof(tokens[3].c_str()));
         }
@@ -138,6 +138,8 @@ int Scene::loadCamera() {
 	camera.right = glm::normalize(glm::cross(camera.view, camera.up));
 	camera.pixelLength = glm::vec2(2 * xscaled / (float)camera.resolution.x
 							, 2 * yscaled / (float)camera.resolution.y);
+
+    camera.view = glm::normalize(camera.lookAt - camera.position);
 
     //set up render camera stuff
     int arraylen = camera.resolution.x * camera.resolution.y;

--- a/src/sceneStructs.h
+++ b/src/sceneStructs.h
@@ -43,11 +43,12 @@ struct Material {
 struct Camera {
     glm::ivec2 resolution;
     glm::vec3 position;
+    glm::vec3 lookAt;
     glm::vec3 view;
     glm::vec3 up;
-	glm::vec3 right;
+    glm::vec3 right;
     glm::vec2 fov;
-	glm::vec2 pixelLength;
+    glm::vec2 pixelLength;
 };
 
 struct RenderState {


### PR DESCRIPTION
This took waaaaay longer than it should have...

This commit changes the camera to take a `LOOKAT` parameter, which I think is more useful for a mouse-based spherical camera. Left click to rotate the camera, right click to zoom, and middle click and drag to pan the lookAt point around in the X-Z plane.

There's also spacebar to recenter the `lookAt` point to the scene file original.
