### PR TITLE
Fixed function signature mismatch in glslUtility

### DIFF
--- a/src/glslUtility.hpp
+++ b/src/glslUtility.hpp
@@ -10,9 +10,8 @@
 namespace glslUtility {
 
 GLuint createDefaultProgram(const char *attributeLocations[], GLuint numberOfLocations);
-GLuint createProgram(const char *attributeLocations[], GLuint numberOfLocations,
-                     const char *vertexShaderPath, const char *fragmentShaderPath,
-                     const char *geometryShaderPath = 0);
+GLuint createProgram(const char *vertexShaderPath, const char *fragmentShaderPath,
+	const char *attributeLocations[], GLuint numberOfLocations);
 }
 
 #endif


### PR DESCRIPTION
The wrong function signature could cause linker error when used.